### PR TITLE
fix compilation on macOS

### DIFF
--- a/crnlib/crn_mem.cpp
+++ b/crnlib/crn_mem.cpp
@@ -1,13 +1,15 @@
 // File: crn_mem.cpp
 // See Copyright Notice and license at the end of inc/crnlib.h
-#include "crn_core.h"
-#include "crn_console.h"
-#include "../inc/crnlib.h"
 #ifdef __APPLE__
 #include <malloc/malloc.h>
 #else
 #include <malloc.h>
 #endif
+
+#include "crn_core.h"
+#include "crn_console.h"
+#include "../inc/crnlib.h"
+
 #if CRNLIB_USE_WIN32_API
 #include "crn_winhdr.h"
 #endif


### PR DESCRIPTION
for reasons that are beyond my understanding, the current Xcode branch fails to compile on macOS Mojave (using the makefile) with the following error
```
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/mach/mach_types.h:111,
                 from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/malloc/malloc.h:28,
                 from /Users/drewcassidy/Scripts/crunch/crnlib/crn_mem.cpp:9:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/mach/dyld_kernel.h:44:2: error: 'uuid_t' does not name a type; did you mean 'uid_t'?
  uuid_t uuid;
  ^~~~~~
  uid_t
```
I suspect something in the header files that proceed the `#include <malloc/malloc.h>` is messing up type definition in the malloc headers. There is probably a better way to fix this, but I was unable to find it after a few hours of searching for the real root cause.